### PR TITLE
contents長routes時又多了一層，特此修正(to branch: feature/content)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   end
 
-  resource    :channels,      as: 'channel',    path: '/channel', except: [:index] do
+  resource    :channels,      as: 'channel',    path: '/channel', except: :index do
     resource  :channel_roles, as: 'role',       path: '/role',    only:   [:update, :destroy]   do
       collection do
         post :new,            as: 'new',        path: '/new'
@@ -35,11 +35,8 @@ Rails.application.routes.draw do
 
   resources   :link_groups,   as: 'link_group', path: 'link_group'
   resources   :saved_links,   as: 'saved_link', path: 'saved_link'
-  resources   :articles,      as: 'article',    path: 'article',  except: [:index] do
-    member do
-      resource :contents,     only: [:new]
-    end
+  resources   :articles,      as: 'article',    path: 'article',  except: :index do
+    resource :contents,     only: :new
   end
   resources   :contents,      except: [:index, :new]
-  # end # organization
-end  # Rails draw do
+end  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,22 +24,22 @@ Rails.application.routes.draw do
 
   end
 
-  resource    :channels,           as: 'channel',      path: '/channel',      except: [:index] do
-    resource  :channel_roles,      as: 'role',         path: '/role',         only:   [:update, :destroy]   do
+  resource    :channels,      as: 'channel',    path: '/channel', except: [:index] do
+    resource  :channel_roles, as: 'role',       path: '/role',    only:   [:update, :destroy]   do
       collection do
-        post :new,                 as: 'new',          path: '/new'
-        get :create,               as: 'accept',       path: '/:token'
+        post :new,            as: 'new',        path: '/new'
+        get :create,          as: 'accept',     path: '/:token'
       end
     end
   end
 
-  resources   :link_groups,        as: 'link_group',   path: 'link_group'
-  resources   :saved_links,        as: 'saved_link',   path: 'saved_link'
-  resources   :articles,           as: 'article',      path: 'article'
-
-      resources :articles do
-        resources :contents
-      end
-    end # channel
+  resources   :link_groups,   as: 'link_group', path: 'link_group'
+  resources   :saved_links,   as: 'saved_link', path: 'saved_link'
+  resources   :articles,      as: 'article',    path: 'article',  except: [:index] do
+    member do
+      resource :contents,     only: [:new]
+    end
+  end
+  resources   :contents,      except: [:index, :new]
   # end # organization
-# end  # Rails draw do
+end  # Rails draw do


### PR DESCRIPTION
把contents的路徑拉出來，一個降維打擊的概念
這樣可以少一層路徑，使用上比較不會那麼繁瑣
唯contents#new時仍須article_id，故保留在article底下
詳請files changed