### PR TITLE
Deploy fix (v1.0.0) (#80)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p $PORT
 webpack: bin/webpack-dev-server

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,1 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Good
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.assets.initialize_on_precompile = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
1.  modified: Procfile
改掉原預設3000，設定$PROT由heroku自由分配，否則會跟其他使用者打架無法正常上線；
因此後續在電腦上跑專案請用以下方式
<img width="266" alt="image" src="https://user-images.githubusercontent.com/57695762/83215504-b495b600-a199-11ea-82f8-40d5aababb11.png">

2. modified:   app/assets/config/manifest.js
   拿掉//= link_directory ../stylesheets .css，因為我們已不使用asset stylesheet, 沒拿掉會噴錯

3. modified:   config/application.rb
    關掉precompile