### PR TITLE
Redirect fix done.

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -33,7 +33,7 @@ class ChannelsController < ApplicationController
       @notice = "頻道新增失敗"
       path = root_path
     end
-    redirect_to(path, notice: @notice) and return
+    redirect_to(path, notice: @notice)
   end
 
   def update
@@ -42,16 +42,17 @@ class ChannelsController < ApplicationController
     else
       @notice = "頻道更新失敗"
     end
-    redirect_to(edit_channel_path, notice: @notice) and return
+    redirect_to(edit_channel_path, notice: @notice)
   end
 
   def destroy
     if @channel.destroy
+      session["goodbytes7788"]["channel_id"] = @organization.channels.first&.id
       @notice = "頻道刪除成功"
     else
       @notice = "頻道刪除失敗"
     end
-    redirect_to(root_path, notice: @notice) and return
+    redirect_to(channel_path, notice: @notice)
   end
 
   def deliver

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -6,11 +6,13 @@ class OrganizationsController < ApplicationController
     organization = Organization.new(organization_params)
     if organization.save
       organization.update_role(current_user.id, admin)
+      session["goodbytes7788"]["organization_id"] = organization.id
+      session["goodbytes7788"]["channel_id"] = nil
       @notice = '組織新增成功'
     else
       @notice = "組織新增失敗"
     end
-    redirect_to root_path, notice: @notice
+    redirect_to channel_path, notice: @notice
   end
   def edit
     # organization後台頁面
@@ -28,6 +30,7 @@ class OrganizationsController < ApplicationController
 
   def destroy
     if @organization.destroy
+      clean_session
       @notice = "組織刪除成功"
     else
       @notice = "組織刪除失敗"

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -48,7 +48,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # PUT /resource
   def update
-
+    [:name, :password, :password_confirmation].each do |col|
+      params[col] = nil unless params[col].present?
+    end
     @organization = Organization.new
     @messages = current_user.receive_invites.includes(:item).includes(:sender)
     super

--- a/app/views/channels/edit.html.erb
+++ b/app/views/channels/edit.html.erb
@@ -25,6 +25,11 @@
           <li class="nav-item">
           <%= link_to "頻道資料", edit_channel_path, class:"nav-link active" %>
           </li>
+          <div class="org-form pl-5">
+            <div class="form-row align-items-center">
+              <h4>頻道：<%= @channel.name %></h4>
+            </div>
+          </div>
         </ul>
       </div>
     </div>
@@ -137,19 +142,19 @@
         <h6 class="card-title m-0">編輯頻道</h6>
       </div>
       <div class="card-body">
-        <div class="org-form">
-          <div class="form-row align-items-center">
-            <h6>目前所在頻道：<%= @channel.name %></h6>
-          </div>
-        </div>
+        
         <div class="org-form">
           <div class="form-row align-items-center">
             <h6 class="col-auto col-form-label">頻道改名：</h6><%= form_tag(channel_path, method: 'patch') do %>
             <input type="text" name="channel[name]" placeholder="請輸入新名稱">
             <input type="submit" value="送出" class="btn btn-outline-secondary">
             <% end %>
-            <h6 class="col-auto col-form-label">頻道刪除：</h6><%= form_tag(channel_path, method: 'delete') do %>
-            <input type="submit" value="刪除" class="btn btn-outline-info">
+            
+          </div>
+          <div class="form-row align-items-center">
+            <h6 class="col-auto col-form-label">頻道刪除：</h6>
+            <%= form_tag(channel_path, method: 'delete') do %>
+              <%= submit_tag "刪除頻道", class: "btn btn-outline-info", data: {confirm: "確定要刪除頻道 #{@channel.name} ?"} %>
             <% end %>
           </div>
         </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -73,13 +73,18 @@
           
             <div class="field">
               <%= f.label :email, "電子信箱" %><br />
-              <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control", readonly: "true" %>
+              <label><%= resource.email %></label>
             </div>
           
             <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
             <div>此信箱確認中<%= resource.unconfirmed_email %></div>
             <% end %>
-          
+            
+            <div class="field">
+              <%= f.label :name, "更改顯示名稱" %>（如不修改請留白）<br />
+              <%= f.text_field :name, class:"form-control" %> 
+            </div>
+
             <div class="field">
               <%= f.label :password, " 輸入新密碼" %>（如不修改請留白）<br />
               <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %> <small id="emailHelp" class="form-text text-muted"><% if @minimum_password_length %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -25,6 +25,11 @@
           <li class="nav-item">
           <%= link_to "頻道資料", edit_channel_path, class:"nav-link" %>
           </li>
+          <div class="org-form pl-5">
+            <div class="form-row align-items-center">
+              <h4>組織：<%= @organization.name %></h4>
+            </div>
+          </div>
         </ul>
       </div>
     </div>
@@ -165,15 +170,16 @@
       <div class="card-body">
         <div class="org-form">
           <div class="form-row align-items-center">
-            <h6 class="col-auto col-form-label">目前所在組織：<%= @organization.name %></h6>
-          </div>
-        </div>
-        <div class="org-form">
-          <div class="form-row align-items-center">
             <h6 class="col-auto col-form-label">組織改名：</h6>
             <%= form_for(@organization, url: organization_path, method: 'patch') do |f| %>
-            <%= f.text_field :name, placeholder: "請輸入新名稱" %>
+            <%= f.text_field :name, value: "", placeholder: "請輸入新名稱" %>
             <%= f.submit "送出", class: "btn btn-outline-secondary" %>
+            <% end %>
+          </div>
+          <div class="form-row align-items-center">
+            <h6 class="col-auto col-form-label">刪除組織</h6>
+            <%= form_tag(organization_path, method: 'delete') do %>
+              <%= submit_tag "刪除組織", class: "btn btn-outline-info", data: {confirm: "確定要刪除組織 #{@organization.name} ?"} %>
             <% end %>
           </div>
         </div>

--- a/app/views/shared/_breadcrumb.html.erb
+++ b/app/views/shared/_breadcrumb.html.erb
@@ -3,7 +3,7 @@
 
 <ol class="breadcrumb">
   <li class="breadcrumb-item" aria-current="page">
-    <%= link_to current_channel.name, channel_path %>
+    <%= link_to current_channel.name, channel_path if current_channel_id.present? %>
   </li>
 
 

--- a/app/views/shared/_user_section.html.erb
+++ b/app/views/shared/_user_section.html.erb
@@ -3,7 +3,7 @@
   <% if user_signed_in? %>
     <%# 和使用者打招呼 %>
     <%= greet %> ,
-    <strong><%= current_user.email %></strong>
+    <strong><%= current_user.name.present? ? current_user.name : current_user.email %></strong>
   <% else %>
     <%= link_to "Sign up", new_user_registration_path %> |
     <%= link_to "Sign in", new_user_session_path, class: 'navbar-link'  %>

--- a/config/locales/devise.zh-TW.yml
+++ b/config/locales/devise.zh-TW.yml
@@ -113,9 +113,9 @@ zh-TW:
       signed_up_but_inactive: 您已註冊成功。然而因為您的帳號尚未啓動，暫時無法登入，抱歉！
       signed_up_but_locked: 您已註冊成功。 然而因為您的帳號已被鎖定，暫時無法登入，抱歉！
       signed_up_but_unconfirmed: 確認信件已送至您的 Email 信箱，請點擊信件內連結以啓動您的帳號。
-      update_needs_confirmation: 您已經成功的更新帳號資訊，但我們仍需確認您的電子信箱，請至新信箱收信並點擊連結以確認您的新電子郵件帳號。
-      updated: 您已經成功的更新帳號資訊。
-      updated_but_not_signed_in: 您已經成功的更新帳號資訊。但因為您變更了密碼，請重新登入。
+      update_needs_confirmation: 您已成功更新帳戶資料，但我們仍需確認您的電子信箱，請至新信箱收信並點擊連結以確認您的新電子郵件帳號。
+      updated: 您已成功更新帳戶資料。
+      updated_but_not_signed_in: 您已成功更新帳戶資料。但因為您變更了密碼，請重新登入。
     sessions:
       already_signed_out: 登出成功。
       new:


### PR DESCRIPTION
跳轉：
- [x] 組織的頻道被刪除後跳轉第一個orgnization的channel頁，而不是原本的organization
- [x] 編輯頻道及組織名稱後導向channel頁 (我的想法是同一頁)
<del> 取消邀請組織/頻道的路徑導向channel頁 (我的想法是同一頁) </del>
- [x] 修改密碼後重新導向到channel頁 (我的想法是同一頁)

顯示：
- [x] 組織改名有放名稱//頻道改名沒有放
- [x] 頻道跟組織風格太像有可能會搞混
- [x] 修改密碼後，成功及失敗alert是英文

此外，在頁籤處顯示當前組織與頻道名稱

----

- [x] 信箱不給改
- [x] 當前名稱不顯示於input
    - 依然顯示，但不是input
- [x] 名稱修改與密碼修改分開兩個form
    - 作法變成改變controller規則，如果來的是空字串則設為nil，這樣就ok了
- [x] 送出修改時都要輸入原密碼
- [x] 組織刪除鈕